### PR TITLE
Support book names without space

### DIFF
--- a/lib/src/parsers/parser.dart
+++ b/lib/src/parsers/parser.dart
@@ -40,11 +40,17 @@ List<Reference> parseAllReferences(String stringReference) {
 
 Reference _createRefFromMatch(RegExpMatch match) {
   var pr = match.groups([0, 1, 2, 3, 4, 5]);
+  var book = pr[1]!.replaceAllMapped(RegExp(r'(\d+)\s?'), (match) {
+    return '${match.group(1)} ';
+  });
+
   return Reference(
-    Librarian.getBookNames(pr[1])['name'] ?? pr[1]!,
+    Librarian.getBookNames(book)['name'] ?? pr[1]!,
     pr[2] == null ? null : int.parse(pr[2]!),
     pr[3] == null ? null : int.parse(pr[3]!),
-    pr[4] != null && (pr[3] == null || pr[5] != null) ? int.parse(pr[4]!) : null,
+    pr[4] != null && (pr[3] == null || pr[5] != null)
+        ? int.parse(pr[4]!)
+        : null,
     pr[5] != null
         ? int.parse(pr[5]!)
         : pr[4] != null && pr[3] != null
@@ -56,7 +62,7 @@ Reference _createRefFromMatch(RegExpMatch match) {
 RegExp _createFullRegex() {
   var books = BibleData.bookNames.expand((i) => i).toList();
   books.addAll(BibleData.variants.keys);
-  var regBooks = books.join('\\b|\\b');
+  var regBooks = books.map((e) => e.replaceAll(' ', '[ ]?')).join('\\b|\\b');
   var expression =
       '(\\b$regBooks\\b) *(\\d+)?[ :.]*(\\d+)?[— -]*(\\d+)?[ :.]*(\\d+)?';
   var exp = RegExp(expression, caseSensitive: false);

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -98,6 +98,11 @@ void main() {
     expect(ref.reference, equals('1 Corinthians'));
   });
 
+  test('Allow parsing numbered books without spaces', () {
+    var ref = parseReference('1corinthians 1:23');
+    expect(ref.reference, equals('1 Corinthians 1:23'));
+  });
+
   test('Parsing all references', () {
     var refs = parseAllReferences('I hope Matt 2:4 and James 5:1-5 get parsed');
     expect(refs.length, equals(2));

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -101,6 +101,9 @@ void main() {
   test('Allow parsing numbered books without spaces', () {
     var ref = parseReference('1corinthians 1:23');
     expect(ref.reference, equals('1 Corinthians 1:23'));
+
+    ref = parseReference('1tm 2:1-3');
+    expect(ref.reference, equals('1 Timothy 2:1-3'));
   });
 
   test('Parsing all references', () {


### PR DESCRIPTION
This adds support for book names without a space between the number and the book. For example:

```
1corinthians 2:3 // 1 Corinthians 2:3
1tm 1 // 1 Timothy 1
```