### PR TITLE
added flag to ignore lone 'is' in provided text

### DIFF
--- a/lib/src/parsers/parser.dart
+++ b/lib/src/parsers/parser.dart
@@ -14,7 +14,10 @@ final _exp = _createFullRegex();
 ///
 /// **Note**: The word 'is' will be parsed as the book of Isaiah.
 /// An efficient workaround is in the works.
-Reference parseReference(String stringReference) {
+Reference parseReference(String stringReference, {bool ignoreIs = false}) {
+  if (ignoreIs) {
+    stringReference = stringReference.replaceAll(RegExp(r'\bis\b', caseSensitive: false), '');
+  }
   var match = _exp.firstMatch(stringReference);
   if (match == null) return Reference('');
   return _createRefFromMatch(match);
@@ -31,7 +34,10 @@ Reference parseReference(String stringReference) {
 ///
 /// **Note**: The word 'is' will be parsed as the book of Isaiah.
 /// An efficient workaround is in the works.
-List<Reference> parseAllReferences(String stringReference) {
+List<Reference> parseAllReferences(String stringReference, {bool ignoreIs = false}) {
+  if (ignoreIs) {
+    stringReference = stringReference.replaceAll(RegExp(r'\bis\b', caseSensitive: false), '');
+  }
   var refs = <Reference>[];
   var matches = _exp.allMatches(stringReference);
   matches.forEach((x) => refs.add(_createRefFromMatch(x)));


### PR DESCRIPTION
A flag has been added to parseReference() and parseAllReferences() to ignore "is" in a provided string. It will default to false in order to not alter current outputs.

`
parseAllReferences('This is NOT going to get Gen 2:4 and another book', ignoreIs: true);
//returns  [Genesis 2:4] only
`

This flag will not affect any other instances of Isaiah.