### PR TITLE
Replace original string

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -17,7 +17,7 @@ void main() {
   print(ref.reference); // 'Song of Solomon 2:1'
 
   //Range of verses
-  ref = parseReference('Gen 4:5-10');
+  ref = parseReference('My name is Gen 4:5-10', ignoreIs: true);
   print(ref.reference); // 'Genesis 4:5-10'
   print(ref.startVerseNumber); // 5
   print(ref.endVerseNumber); // 10
@@ -49,6 +49,9 @@ void main() {
   print(ref.endVerseNumber); // 5
 
   var refs =
-      parseAllReferences('This is going to get Gen 2:4 and another book');
-  print(refs); // ['Isaiah', 'Genesis 2:4'], 'is' will be parsed as Isaiah
+      parseAllReferences('This is NOT going to get Gen 2:4 and another book', ignoreIs: true);
+  print(refs[0].reference); // ['Isaiah', 'Genesis 2:4'], 'is' will be parsed as Isaiah
+
+  var x = parseReferencesAndReplaceString('This is going to get Gen 2:4 reference and update the original string.', ignoreIs: true);
+  print(x);
 }

--- a/lib/src/parsers/parser.dart
+++ b/lib/src/parsers/parser.dart
@@ -44,6 +44,40 @@ List<Reference> parseAllReferences(String stringReference, {bool ignoreIs = fals
   return refs;
 }
 
+String parseReferencesAndReplaceString(String stringReference, {bool ignoreIs = false}) {
+   if (ignoreIs) {
+    stringReference = stringReference.replaceAll(
+        RegExp(r'\bis\b', caseSensitive: false), '%%');
+  }
+
+  var matches = _exp.allMatches(stringReference);
+  var originalString = stringReference;
+
+  matches.forEach((x) {
+    var reference = _createRefFromMatch(x);
+    var matchedString = x.group(0);
+    if (matchedString != null) {
+      var punct = RegExp(r'[.,;!?]\s*$');
+      var replacementString = reference.toString();
+
+      if (punct.hasMatch(matchedString)) {
+        if (matchedString.length > 1) {
+          replacementString += matchedString[matchedString.length - 2];
+        }
+      }
+      replacementString += ' ';
+
+      originalString =
+          originalString.replaceFirst(matchedString, replacementString);
+    }
+  });
+
+  if (ignoreIs) {
+    originalString = originalString.replaceAll('%%', 'is');
+  }
+
+  return originalString;
+}
 Reference _createRefFromMatch(RegExpMatch match) {
   var pr = match.groups([0, 1, 2, 3, 4, 5]);
   var book = pr[1]!.replaceAllMapped(RegExp(r'(\d+)\s?'), (match) {

--- a/lib/src/parsers/parser.dart
+++ b/lib/src/parsers/parser.dart
@@ -14,7 +14,10 @@ final _exp = _createFullRegex();
 ///
 /// **Note**: The word 'is' will be parsed as the book of Isaiah.
 /// An efficient workaround is in the works.
-Reference parseReference(String stringReference) {
+Reference parseReference(String stringReference, {bool ignoreIs = false}) {
+  if (ignoreIs) {
+    stringReference = stringReference.replaceAll(RegExp(r'\bis\b', caseSensitive: false), '');
+  }
   var match = _exp.firstMatch(stringReference);
   if (match == null) return Reference('');
   return _createRefFromMatch(match);
@@ -31,7 +34,10 @@ Reference parseReference(String stringReference) {
 ///
 /// **Note**: The word 'is' will be parsed as the book of Isaiah.
 /// An efficient workaround is in the works.
-List<Reference> parseAllReferences(String stringReference) {
+List<Reference> parseAllReferences(String stringReference, {bool ignoreIs = false}) {
+  if (ignoreIs) {
+    stringReference = stringReference.replaceAll(RegExp(r'\bis\b', caseSensitive: false), '');
+  }
   var refs = <Reference>[];
   var matches = _exp.allMatches(stringReference);
   matches.forEach((x) => refs.add(_createRefFromMatch(x)));

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -128,6 +128,27 @@ void main() {
         reason: 'This string contains no references');
   });
 
+  test('Parsing and replacing references', () {
+    String result = parseReferencesAndReplaceString('There is hope that Matt 2:4 and jas 5:1-5 get parsed');
+    expect(result.contains('Matthew 2:4'), true);
+    expect(result.contains('James 5:1-5'), true);
+    expect(result.contains('Isaiah'), true);
+    expect(result.contains('Matt 2:4'), false);
+    expect(result.contains('jas 5:1-5'), false);
+    expect(result.contains('is'), false);
+    expect(result, equals('There Isaiah hope that Matthew 2:4 and James 5:1-5 get parsed'));
+  });
+
+  test('Parsing and replacing references with ignoreIs flag', () {
+    String result = parseReferencesAndReplaceString('There is hope that Matt 2:4 and jas 5:1-5 get parsed', ignoreIs: true);
+    expect(result.contains('Matthew 2:4'), true);
+    expect(result.contains('James 5:1-5'), true);
+    expect(result.contains('Isaiah'), false);
+    expect(result.contains('Matt 2:4'), false);
+    expect(result.contains('jas 5:1-5'), false);
+    expect(result.contains('is'), true);
+    expect(result, equals('There is hope that Matthew 2:4 and James 5:1-5 get parsed'));
+  });
   test('Verify paratexts', () {
     var refs = parseAllReferences('Mat Jam PSA joh');
     refs.forEach((x) {


### PR DESCRIPTION
Simple function that will replace the found references in the provided string with the formatted reference and return the string contents. Argument for reference format could be implemented.